### PR TITLE
Updated silex dependency to allow all versions < 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "silex/silex": "1.0.*@dev"
+        "silex/silex": "~1.0"
     },
     "autoload": {
         "psr-0": { "Mach\\Silex\\Rest\\": "src" }


### PR DESCRIPTION
This change allows the package to be used by projects built on all 1.x Silex releases.